### PR TITLE
Set rootProject.name to yo in settings.gradle

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'yo'


### PR DESCRIPTION
We need to set this so that we can build yo on CI, otherwise the output jar is named after the checkout directory (e.g. 9042b434fbccd8d1-4.jar)